### PR TITLE
fix: pin to old version of azure regions module

### DIFF
--- a/availability_zones.tf
+++ b/availability_zones.tf
@@ -4,6 +4,6 @@ locals {
 
 module "regions" {
   source                   = "Azure/regions/azurerm"
-  version                  = ">= 0.5.2"
+  version                  = "0.5.2"
   recommended_regions_only = false
 }


### PR DESCRIPTION
Looks like the latest version of this module may have a bug. We verified that the version we started with still works, so we'll pin to that one for now.