### PR TITLE
Enable oidc_issuer_enabled flag to get OIDC issuer URL

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -43,6 +43,7 @@ module "aks" {
   network_plugin                    = "azure"
   network_policy                    = "azure"
   os_disk_size_gb                   = 60
+  oidc_issuer_enabled               = true
   private_cluster_enabled           = false
   role_based_access_control_enabled = true
   rbac_aad                          = true


### PR DESCRIPTION
This fixes https://github.com/nuonco/terraform-azure-aks-sandbox/issues/23

As per the [AKS module document](https://registry.terraform.io/modules/Azure/aks/azurerm/latest?tab=inputs), `oidc_issuer_enabled` default value is `false`, because of which the nuon module is returning empty value for `oidc_issuer_url`.